### PR TITLE
Short circuit binary op when either side is empty

### DIFF
--- a/vendor/github.com/prometheus/prometheus/promql/engine.go
+++ b/vendor/github.com/prometheus/prometheus/promql/engine.go
@@ -1897,6 +1897,9 @@ func (ev *evaluator) VectorBinop(op parser.ItemType, lhs, rhs Vector, matching *
 	if matching.Card == parser.CardManyToMany {
 		panic("many-to-many only allowed for set operators")
 	}
+	if len(lhs) == 0 || len(rhs) == 0 {
+		return nil // Short-circuit: nothing is going to match.
+	}
 	sigf := enh.signatureFunc(matching.On, matching.MatchingLabels...)
 
 	// The control flow below handles one-to-one or many-to-one matching.


### PR DESCRIPTION
This is a short-term fix for https://github.com/jacksontj/promxy/issues/527. It turns out this is not a promxy bug, but really a Prometheus bug that has been fixed with this PR: https://github.com/prometheus/prometheus/pull/9362

So if promxy sync-up its forked version of Prometheus code, this should be fixed. That's a big effort, so for the short-term, we can copy the short-circuit logic in the latest Prometheus code.